### PR TITLE
Fix Symfony deprecation notices, add return type hints

### DIFF
--- a/src/DependencyInjection/BGObjectRoutingExtension.php
+++ b/src/DependencyInjection/BGObjectRoutingExtension.php
@@ -12,7 +12,7 @@ class BGObjectRoutingExtension extends Extension
     /**
      * {@inheritDoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -7,7 +7,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('bg_object_routing');
 


### PR DESCRIPTION
This hopefully improves Symfony forward compatibility.

Adding a return type hint where the base class does not return type hint at all is possible even in PHP 7.2.