### PR TITLE
Support configuration with PHP 8 attributes through `AttributeDriver`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
     },
 
     "require": {
-        "php": ">= 7.2, < 8.4",
+        "php": "^8.1",
         "symfony/config": "^5.0|^6.0|^7.0",
         "symfony/dependency-injection": "^5.0|^6.0|^7.0",
         "symfony/http-kernel": "^5.0|^6.0|^7.0",
-        "webfactory/object-routing": "^1.6",
+        "webfactory/object-routing": "^1.7",
         "jms/metadata": "^2.6"
     },
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -34,10 +34,12 @@
         <service id="Metadata\Driver\DriverInterface" alias="Metadata\Driver\DriverChain" public="true" />
         <service id="Metadata\Driver\DriverChain">
             <argument type="collection">
+                <argument type="service" id="JMS\ObjectRouting\Metadata\Driver\AttributeDriver" />
                 <argument type="service" id="JMS\ObjectRouting\Metadata\Driver\AnnotationDriver" />
             </argument>
         </service>
 
+        <service id="JMS\ObjectRouting\Metadata\Driver\AttributeDriver" />
         <service id="JMS\ObjectRouting\Metadata\Driver\AnnotationDriver">
             <argument type="service" id="annotation_reader" />
         </service>


### PR DESCRIPTION
This registers the new `AttributeDriver` added in https://github.com/webfactory/object-routing/releases/tag/1.7.0. 

In the next major version, we can then remove the `AnnotationDriver` and get rid of the `annotation_reader` service dependency.