### PR TITLE
[BC break] Remove `AnnotationDriver` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * The `bg_object_routing.adapter` service has been removed. It was an alias for `JMS\ObjectRouting\RouterInterface`, use that service ID instead (or use autowiring).
 * The `bg_object_routing.object_router` service has been removed. It was an alias for `JMS\ObjectRouting\ObjectRouter`, use that service ID instead (or use autowiring).
+* The `AnnotationDriver` has been removed from the driver chain. Use PHP 8 attributes instead of annotations for object route definitions. 
 
 # Version 2.0.0
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -21,12 +21,10 @@
         <service id="Metadata\Driver\DriverChain">
             <argument type="collection">
                 <argument type="service" id="JMS\ObjectRouting\Metadata\Driver\AttributeDriver" />
-                <argument type="service" id="JMS\ObjectRouting\Metadata\Driver\AnnotationDriver" />
             </argument>
         </service>
 
         <service id="JMS\ObjectRouting\Metadata\Driver\AttributeDriver" />
-        <service id="JMS\ObjectRouting\Metadata\Driver\AnnotationDriver" />
 
         <service id="Metadata\Cache\CacheInterface" alias="Metadata\Cache\FileCache" />
 


### PR DESCRIPTION
This removes the `AnnotationDriver` from the chain of registered drivers, thereby getting rid of the `annotation_reader` service dependency.

The `annotation_reader` was provided by `symfony/framework-bundle`, but has been removed in Symfony 7. Thus, this change fixes a Symfony 7 compatibility issue.