### PR TITLE
Declare compatibility with webfactory/object-routing ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/config": "^5.0|^6.0|^7.0",
         "symfony/dependency-injection": "^5.0|^6.0|^7.0",
         "symfony/http-kernel": "^5.0|^6.0|^7.0",
-        "webfactory/object-routing": "^1.7",
+        "webfactory/object-routing": "^1.7|^2.0",
         "jms/metadata": "^2.6"
     },
 


### PR DESCRIPTION
webfactory/object-routing 2.0.0 drops annotations support. This has been prepared by #10, so we're already compatible with that new version.